### PR TITLE
feat: add the link for contributors

### DIFF
--- a/apps/web/app/components/ui/navigation/DropdownUserProfile.tsx
+++ b/apps/web/app/components/ui/navigation/DropdownUserProfile.tsx
@@ -118,6 +118,15 @@ export function DropdownUserProfile({
                 aria-hidden="true"
               />
             </DropdownMenuItem>
+            <DropdownMenuItem>
+              <a href="https://github.com/ToyB0x/git-dash" target="_blank" rel="noopener noreferrer" className="w-full flex items-center">
+                Contribution             
+                <RiArrowRightUpLine
+                  className="mb-1 ml-1 size-2.5 shrink-0 text-gray-500"
+                  aria-hidden="true"
+                />
+              </a>
+            </DropdownMenuItem>
           </DropdownMenuGroup>
           <DropdownMenuSeparator />
           <DropdownMenuGroup>


### PR DESCRIPTION
I added the link for the contributors as one of the setting link list which shows up at the profile button.

<img width="1285" alt="スクリーンショット 2025-02-22 13 32 09" src="https://github.com/user-attachments/assets/34e825ca-ea14-4b4f-9837-5f8390d42a7e" />
