### PR TITLE
fix: tooltip position

### DIFF
--- a/apps/web/app/components/LineChart.tsx
+++ b/apps/web/app/components/LineChart.tsx
@@ -725,7 +725,7 @@ const LineChart = React.forwardRef<HTMLDivElement, LineChartProps>(
               animationDuration={100}
               cursor={{ stroke: "#d1d5db", strokeWidth: 1 }}
               offset={20}
-              position={{ y: 0 }}
+              position={{ y: 100 }}
               content={
                 showTooltip ? (
                   ({ active, payload, label }) =>


### PR DESCRIPTION
when I tried to check the chart, I found the tooltip displayed over the cursor and it is more confusing and becomes more frustrating that I cant see where I am pointing.

I positioned it right below at the chart.
What do you think?

before

https://github.com/user-attachments/assets/63c9aac2-5d84-45e8-8cb2-8f3977962b0c

after

https://github.com/user-attachments/assets/88c40271-8013-4881-ae19-f247eae48204